### PR TITLE
Add foundational unit tests and pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the root of the repository is on the Python path so `src` can be imported
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_chi.py
+++ b/tests/test_chi.py
@@ -1,0 +1,57 @@
+import pytest
+pytest.importorskip('mdtraj')
+import mdtraj as md
+from src.utils.chi import get_atom_indices_by_name, get_dihed_idxs
+
+
+def _build_topology_with_gly():
+    top = md.Topology()
+    chain = top.add_chain()
+
+    def add_res(name, has_cb=True):
+        res = top.add_residue(name, chain)
+        top.add_atom('N', md.element.nitrogen, res)
+        top.add_atom('CA', md.element.carbon, res)
+        if has_cb:
+            top.add_atom('CB', md.element.carbon, res)
+        top.add_atom('C', md.element.carbon, res)
+        top.add_atom('O', md.element.oxygen, res)
+        return res
+
+    res1 = add_res('ALA', has_cb=True)
+    res2 = add_res('GLY', has_cb=False)
+    return top, res1, res2
+
+
+def _build_topology_two_res():
+    top = md.Topology()
+    chain = top.add_chain()
+    for name in ['ALA', 'VAL']:
+        res = top.add_residue(name, chain)
+        top.add_atom('N', md.element.nitrogen, res)
+        top.add_atom('CA', md.element.carbon, res)
+        top.add_atom('CB', md.element.carbon, res)
+        top.add_atom('C', md.element.carbon, res)
+        top.add_atom('O', md.element.oxygen, res)
+    return top
+
+
+def test_get_atom_indices_by_name():
+    top, res1, res2 = _build_topology_with_gly()
+    idxs = get_atom_indices_by_name(top, res1, ['N', 'CA', 'CB', 'C'])
+    assert idxs[0] == res1.atom('N').index
+    assert idxs[2] == res1.atom('CB').index
+
+    idxs2 = get_atom_indices_by_name(top, res2, ['N', 'CA', 'CB', 'C'])
+    assert idxs2[2] is None
+
+
+def test_get_dihed_idxs():
+    top = _build_topology_two_res()
+    dihed = get_dihed_idxs(top)
+    assert len(dihed) == 2
+    n_idx = top.residue(0).atom('N').index
+    ca_idx = top.residue(0).atom('CA').index
+    cb_idx = top.residue(0).atom('CB').index
+    c_idx = top.residue(0).atom('C').index
+    assert dihed[0] == [n_idx, ca_idx, cb_idx, c_idx]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,45 @@
+import pytest
+pytest.importorskip('numpy')
+pytest.importorskip('rdkit')
+pytest.importorskip('mdtraj')
+pytest.importorskip('torch')
+
+import numpy as np
+import mdtraj as md
+import torch
+from rdkit import Chem
+from rdkit.Chem import AllChem
+import tempfile
+
+from src.utils.energy import rdkit_traj_to_energy, EnergyModel
+
+
+def _build_rdkit_molecule():
+    mol = Chem.AddHs(Chem.MolFromSmiles('CCO'))
+    AllChem.EmbedMolecule(mol, randomSeed=0xf00d)
+    AllChem.UFFOptimizeMolecule(mol)
+    block = Chem.MolToPDBBlock(mol)
+    with tempfile.NamedTemporaryFile('w+', suffix='.pdb') as tmp:
+        tmp.write(block)
+        tmp.flush()
+        traj = md.load(tmp.name)
+    return mol, traj.topology, traj.xyz.astype(np.float32)
+
+
+def test_rdkit_energy_model_end_to_end():
+    mol, top, xyz = _build_rdkit_molecule()
+    energies, grads = rdkit_traj_to_energy(top, xyz)
+    assert energies.shape == (1,)
+    assert grads.shape == xyz.shape
+    assert np.all(np.isfinite(grads))
+
+    ff = AllChem.UFFGetMoleculeForceField(mol)
+    expected = ff.CalcEnergy()
+    assert np.allclose(energies[0], expected, atol=1e-5)
+
+    model = EnergyModel(rdkit_traj_to_energy, top)
+    x = torch.tensor(xyz, requires_grad=True)
+    out = model(x)
+    out.sum().backward()
+    assert x.grad.shape == x.shape
+    assert torch.all(torch.isfinite(x.grad))

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,0 +1,45 @@
+import pytest
+
+pytest.importorskip('rdkit')
+pytest.importorskip('openmm')
+pytest.importorskip('numpy')
+pytest.importorskip('torch')
+pytest.importorskip('mdtraj')
+
+import numpy as np
+import torch
+import mdtraj as md
+
+from src.utils.energy import compute_all_distances, EnergyModel
+
+def _create_simple_traj():
+    top = md.Topology()
+    chain = top.add_chain()
+    res = top.add_residue('ALA', chain)
+    top.add_atom('C1', md.element.carbon, res)
+    top.add_atom('C2', md.element.carbon, res)
+    top.add_atom('C3', md.element.carbon, res)
+    xyz = np.array([[[0.0, 0.0, 0.0],
+                     [1.0, 0.0, 0.0],
+                     [0.0, 2.0, 0.0]]], dtype=np.float32)
+    traj = md.Trajectory(xyz, top)
+    return traj
+
+def dummy_energy(topology, coords):
+    energy = np.sum(coords ** 2, axis=(1, 2))
+    gradient = 2 * coords
+    return energy, gradient
+
+def test_compute_all_distances():
+    traj = _create_simple_traj()
+    dists = compute_all_distances(traj)
+    assert dists.shape == (1, 3)
+    expected = np.array([[1.0, 2.0, np.sqrt(5.0)]])
+    assert np.allclose(dists, expected, atol=1e-6)
+
+def test_energy_model_autograd():
+    model = EnergyModel(dummy_energy, topology=None)
+    x = torch.randn(1, 2, 3, requires_grad=True)
+    energy = model(x)
+    energy.sum().backward()
+    assert torch.allclose(x.grad, 2 * x)

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,12 @@
+import pytest
+pytest.importorskip('matplotlib')
+pytest.importorskip('torch')
+import torch
+from src.utils.model import generate_cos_pos_encoding
+
+
+def test_generate_cos_pos_encoding_basic():
+    enc = generate_cos_pos_encoding(2, 4, device='cpu')
+    assert enc.shape == (2, 4)
+    assert torch.allclose(enc[0, ::2], torch.zeros(2))
+    assert torch.allclose(enc[0, 1::2], torch.ones(2))

--- a/tests/test_scripts_cli.py
+++ b/tests/test_scripts_cli.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = [
+    ("train.py", ["torch"]),
+    ("pre_train.py", ["torch", "pytorch_lightning"]),
+    ("post_train.py", ["torch", "pytorch_lightning", "mdtraj"]),
+    ("eval.py", ["torch", "mdtraj", "sidechainnet"]),
+]
+
+@pytest.mark.parametrize("script,deps", SCRIPTS)
+def test_script_help(script, deps):
+    for mod in deps:
+        pytest.importorskip(mod)
+    script_path = Path(__file__).resolve().parents[1] / "src" / "scripts" / script
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    output = result.stdout.lower() + result.stderr.lower()
+    assert "usage" in output


### PR DESCRIPTION
## Summary
- add pytest configuration and conftest for path setup
- provide unit tests for chi utilities and foundational energy/model helpers
- ensure tests skip gracefully when heavy dependencies are missing
- include RDKit-based end-to-end energy model test with autograd check
- add smoke tests for training, pre/post-training, and evaluation scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b75cae5398832eb2695ec7afc41bca